### PR TITLE
Add Router status support to neutron plugin.

### DIFF
--- a/openstacknagios/neutron/Routers.py
+++ b/openstacknagios/neutron/Routers.py
@@ -1,0 +1,114 @@
+#
+#    Copyright (C) 2016  Jordan Tardif  http://github.com/jordant
+#    Jordan Tardif <jordan@dreamhost.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#  
+"""
+   Nagios plugin to check router status. Router status is an extended feature
+   provided to neutron via astara. https://github.com/openstack/astara . This
+   plugin will **NOT** work for neutron servers without astara extensions.
+
+   This corresponds to the output of 'neutron router-list -c id -c status'.
+"""
+
+import openstacknagios.openstacknagios as osnag
+
+import keystoneclient.v2_0.client as ks
+
+from neutronclient.neutron import client
+
+
+class NeutronRouters(osnag.Resource):
+    """
+    Determines the number of assigned (used and unused) floating ip's
+
+    """
+
+    def __init__(self, args=None):
+        self.openstack = self.get_openstack_vars(args=args)
+        osnag.Resource.__init__(self)
+
+    def probe(self):
+        try:
+            k = ks.Client(username=self.openstack['username'],
+                          password=self.openstack['password'],
+                          tenant_name=self.openstack['tenant_name'],
+                          auth_url=self.openstack['auth_url'],
+                          cacert=self.openstack['cacert'],
+                          insecure=self.openstack['insecure'])
+        except Exception as e:
+            self.exit_error('cannot get token ' + str(e))
+         
+        try:
+            neutron = client.Client('2.0',
+                                    endpoint_url=k.service_catalog.url_for(
+                                        endpoint_type='public',
+                                        service_type='network'),
+                                    token=k.auth_token, 
+                                    ca_cert=self.openstack['cacert'],
+                                    insecure=self.openstack['insecure'])
+        except Exception as e:
+            self.exit_error('cannot load ' + str(e))
+
+        try:
+            result = neutron.list_routers()
+        except Exception as e:
+            self.exit_error(str(e))
+
+        stati = dict(active=0, down=0, build=0)
+
+        for router in result['routers']:
+            if router['status'] == 'ACTIVE':
+                stati['active'] += 1
+            if router['status'] == 'DOWN':
+                stati['down'] += 1
+            if router['status'] == 'BUILD':
+                stati['build'] += 1
+
+        for r in stati.keys():
+            yield osnag.Metric(r, stati[r], min=0)
+
+
+@osnag.guarded
+def main():
+    argp = osnag.ArgumentParser(description=__doc__)
+
+    argp.add_argument('-w', '--warn', metavar='RANGE', default='0:',
+                      help="""return warning if number of down routers is
+                      greater than (default: 0)""")
+    argp.add_argument('-c', '--critical', metavar='RANGE', default='10:',
+                      help="""return critical if number of down routers is
+                      greater than (default: 10) """)
+    argp.add_argument('--warn_build', metavar='RANGE', default='0:',
+                      help="""return warning if number of building routers is
+                      greater than (default: 0)""")
+    argp.add_argument('--critical_build', metavar='RANGE', default='10:',
+                      help="""return critical if number of building routers
+                      is greater than (default: 10) """)
+
+    args = argp.parse_args()
+
+    check = osnag.Check(
+        NeutronRouters(args=args),
+        osnag.ScalarContext('active'),
+        osnag.ScalarContext('down', args.warn, args.critical),
+        osnag.ScalarContext('build', args.warn_build, args.critical_build),
+        osnag.Summary(show=['active', 'down', 'build'])
+        )
+    check.main(verbose=args.verbose, timeout=args.timeout)
+
+if __name__ == '__main__':
+    main()
+

--- a/openstacknagios/neutron/Routers.py
+++ b/openstacknagios/neutron/Routers.py
@@ -32,7 +32,7 @@ from neutronclient.neutron import client
 
 class NeutronRouters(osnag.Resource):
     """
-    Determines the number of assigned (used and unused) floating ip's
+    Determines the number down/build/active routers
 
     """
 

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ setup(
             'check_cinder-services=openstacknagios.cinder.Services:main',
             'check_neutron-agents=openstacknagios.neutron.Agents:main',
             'check_neutron-floatingips=openstacknagios.neutron.Floatingips:main',
+            'check_neutron-routers=openstacknagios.neutron.Routers:main',
             'check_keystone-token=openstacknagios.keystone.Token:main',
             'check_ceilometer-statistics=openstacknagios.ceilometer.Statistics:main',
             'check_rally-results=openstacknagios.rally.Results:main',


### PR DESCRIPTION
This will check neutron router statuses and alert
on configurable thresholds. Using this plugin requires
astara extensions configured in neutron (https://github.com/openstack/astara)
